### PR TITLE
Fix #72 - changing convention for ENV usrname

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ There are three main directories in the `ui-react/src/` folder:
 * Alternatively, username, password and domain can be set as environment variable
 
     ```bash
-    export USERNAME=svcacct_email@domain.com
+    export USRNAME=svcacct_email@domain.com
     export PASSWORD=password
     export DOMAIN=domain.com
     ```

--- a/config/auth.js
+++ b/config/auth.js
@@ -2,7 +2,7 @@
 module.exports = {
   // this user MUST have full access to all the room accounts
   'exchange' : {
-    'username'  : process.env.USERNAME || 'SVCACCT_EMAIL@DOMAIN.COM',
+    'username'  : process.env.USRNAME || process.env.USERNAME || 'SVCACCT_EMAIL@DOMAIN.COM',
     'password'  : process.env.PASSWORD || 'PASSWORD',
     'uri'       : 'https://outlook.office365.com/EWS/Exchange.asmx'
   },


### PR DESCRIPTION
Tested on windows and now it respects the ENV settings. Code change is simple and should be backwards compatible with older env settings too.